### PR TITLE
feat: add album option

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -217,7 +217,7 @@ async function upload({ email, password, server, directory, yes: assumeYes, dele
 
         const serverAlbums = await getAlbumsFromServer(endpoint, accessToken);
 
-        if (typeof createAlbum === 'boolean') {
+        if (typeof createAlbums === 'boolean') {
           progressBar.start(assetDirectoryMap.size, 0);
 
           for (const localAlbum of assetDirectoryMap.keys()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "immich",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "immich",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.0",


### PR DESCRIPTION
Added option to create or update albums either dynamically by the asset's parent directory name or a given album name.
Will only add new assets to the album(s).  
Addresses #17 