### PR TITLE
fix: reliable asset id and concurrent upload threads

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -115,9 +115,7 @@ async function upload({ email, password, server, directory, yes: assumeYes, dele
     if (SUPPORTED_MIME.includes(mimeType)) {
       const fileStat = fs.statSync(filePath);
       localAssets.push({
-        id: Math.round(
-          fileStat.ctimeMs + fileStat.mtimeMs + fileStat.birthtimeMs
-        ).toString(),
+        id: `${path.basename(filePath)}-${fileStat.size}`.replace(/\s+/g, ''),
         filePath,
       });
     }

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -14,6 +14,7 @@ import * as exifr from 'exifr';
 import * as mime from 'mime-types';
 import chalk from 'chalk';
 import pjson from '../package.json';
+import pLimit from "p-limit";
 
 const log = console.log;
 const rl = readline.createInterface({
@@ -71,11 +72,16 @@ program
       'IMMICH_DELETE_ASSETS'
     )
   )
+  .addOption(
+    new Option('-t, --threads', 'Amount of concurrent upload threads (default=5)').env(
+      'IMMICH_UPLOAD_THREADS'
+    )
+  )
   .action(upload);
 
 program.parse(process.argv);
 
-async function upload({ email, password, server, directory, yes: assumeYes, delete: deleteAssets }: any) {
+async function upload({ email, password, server, directory, yes: assumeYes, delete: deleteAssets, uploadThreads }: any) {
   const endpoint = server;
   const deviceId = (await si.uuid()).os || 'CLI';
   const osInfo = (await si.osInfo()).distro;
@@ -175,26 +181,33 @@ async function upload({ email, password, server, directory, yes: assumeYes, dele
       );
       progressBar.start(newAssets.length, 0);
 
+      const uploadQueue = [];
+
+      const limit = pLimit(uploadThreads ?? 5);
+
       for (const asset of newAssets) {
-        try {
-          const res = await startUpload(endpoint, accessToken, asset, deviceId);
+        uploadQueue.push(limit(async () => {
+          try {
+            const res = await startUpload(endpoint, accessToken, asset, deviceId);
 
-          if (res && res.status == 201) {
-            progressBar.increment();
-            if (deleteLocalAsset == 'y') {
-              fs.unlink(asset.filePath, (err) => {
-                if (err) {
-                  log(err)
-                  return
-                }
-              })
-
+            if (res && res.status == 201) {
+              progressBar.increment();
+              if (deleteLocalAsset == 'y') {
+                fs.unlink(asset.filePath, (err) => {
+                  if (err) {
+                    log(err)
+                    return
+                  }
+                })
+              }
             }
+          } catch (err) {
+            log(chalk.red(err.message));
           }
-        } catch (err) {
-          log(chalk.red(err.message));
-        }
+        }))
       }
+
+      const uploads = await Promise.all(uploadQueue)
 
       progressBar.stop();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "get-video-duration": "^4.0.0",
         "mime-types": "^2.1.34",
         "node-machine-id": "^1.1.12",
+        "p-limit": "3.1.0",
         "simple-thumbnail": "^1.6.5",
         "systeminformation": "^5.11.6"
       },
@@ -511,6 +512,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -700,6 +715,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -1039,6 +1065,14 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1157,6 +1191,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "immich",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "immich",
-      "version": "0.17.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "get-video-duration": "^4.0.0",
     "mime-types": "^2.1.34",
     "node-machine-id": "^1.1.12",
+    "p-limit": "3.1.0",
     "simple-thumbnail": "^1.6.5",
     "systeminformation": "^5.11.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immich",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Immich CLI",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
Making asset IDs use filename and filesize for the asset id.

Adds concurrent file uploading controllable with the -t or --threads parameter.