### PR TITLE
fix: reduce memory usage by fixing stream backpressure bug

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -368,6 +368,7 @@ async function startUpload(
 
     const config: AxiosRequestConfig<any> = {
       method: "post",
+      maxRedirects: 0,
       url: `${endpoint}/asset/upload`,
       headers: {
         Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
Axios has a bug where if maxRedirects aren't set to zero the redirect module will automatically buffer the entire stream into memory incase there are redirects. Setting maxRedirects to zero means the stream is consumed as expected from disk instead of being read fully into memory first. 

This resolves #30 