### PR TITLE
Split large requests to create albums into several small ones

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -430,16 +430,20 @@ async function addAssetsToAlbum(
   albumId: string,
   assetIds: string[]
 ) {
-  try {
-    await axios.put(
-      `${endpoint}/album/${albumId}/assets`,
-      { assetIds: [...new Set(assetIds)] },
-      {
-        headers: { Authorization: `Bearer ${accessToken} ` },
-      }
-    );
-  } catch (e) {
-    log(chalk.red("Error adding asset to album"), e);
+  const sliceSize = 300
+  for(let i = 0; (i * sliceSize) < assetIds.length; i++) {
+    let assetIdsSlice = assetIds.slice(i * sliceSize, (i + 1) * sliceSize)
+    try {
+      await axios.put(
+          `${endpoint}/album/${albumId}/assets`,
+          { assetIds: [...new Set(assetIdsSlice)] },
+          {
+            headers: { Authorization: `Bearer ${accessToken} ` },
+          }
+      );
+    } catch (e) {
+      log(chalk.red("Error adding asset to album"), e);
+    }
   }
 }
 


### PR DESCRIPTION
When using the tool, I received "413 Request Entity Too Large" for particularly large albums. This happens when the put request for album creation becomes too large. The large number of ids can exceed the maximum size of the request.

My change divides the request into individual parts and creates large albums gradually through several requests.