### PR TITLE
fix: Add existing assets to albums

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -93,7 +93,7 @@ program
   .addOption(
     new Option(
       "-al, --album [album]",
-      "Create albums for assets based on the parent folder or a given name. Only adds new assets to the album(s)"
+      "Create albums for assets based on the parent folder or a given name"
     ).env("IMMICH_CREATE_ALBUMS")
   )
   .action(upload);

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -167,15 +167,23 @@ async function upload({
     deviceId
   );
 
-  if (localAssets.length == 0) {
+  const newAssets = localAssets.filter(a => !backupAsset.includes(a.id));
+  if (localAssets.length == 0 || (newAssets.length == 0 && !createAlbums)) {
     log(chalk.green("There are no assets to backup"));
     process.exit(0);
   } else {
     log(
       chalk.green(
-        `A total of ${localAssets.length} assets will be uploaded to the server`
+        `A total of ${newAssets.length} assets will be uploaded to the server`
       )
     );
+  }
+
+  if (createAlbums) {
+    log(chalk.green(
+      `A total of ${localAssets.length} assets will be added to album(s).\n` +
+      "NOTE: some assets may already be associated with the album, this will not create duplicates."
+    ));
   }
 
   // Ask user

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -257,7 +257,7 @@ async function upload({
                     deviceId,
                   },
                   {
-                    headers: { Authorization: `Bearer ${accessToken} ` },
+                    headers: { "x-api-key": key },
                   }
                 );
                 assetDirectoryMap.get(album)!.push(res!.data.id);

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -229,7 +229,7 @@ async function upload({
                   deviceId,
                 );
                 progressBar.increment(1, { filepath: asset.filePath });
-                if (res && res.status == 201) {
+                if (res && (res.status == 201 || res.status == 200)) {
                   if (deleteLocalAsset == "y") {
                     fs.unlink(asset.filePath, (err) => {
                       if (err) {


### PR DESCRIPTION
If an asset already exists on the server, it was being skipped entirely.  In the upload case, this makes sense, but when adding assets to albums, we may want to add the same asset to multiple albums.  So we shouldn't just ignore the asset altogether.

This PR updates the CLI to account for assets that already exist on the server if "createAlbum" is set, so all new and existing local assets are added to albums.

Fixes #45 