### PR TITLE
Make date and time extraction consistent with immich

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -23,7 +23,7 @@ const rl = readline.createInterface({
 });
 let errorAssets: any[] = [];
 
-const SUPPORTED_MIME = [
+const SUPPORTED_MIME_TYPES = [
   // IMAGES
   "image/heif",
   "image/heic",
@@ -49,26 +49,26 @@ const SUPPORTED_MIME = [
 ];
 
 program
-  .name("Immich CLI Utilities")
-  .description("Immich CLI Utilities toolset")
+  .name("Immich CLI")
+  .description("Immich command line interface based on nodejs")
   .version(pjson.version);
 
 program
   .command("upload")
-  .description("Upload images and videos in a directory to Immich's server")
+  .description("Upload assets to an Immich instance")
   .addOption(
     new Option("-k, --key <value>", "API Key").env("IMMICH_API_KEY")
   )
   .addOption(
     new Option(
       "-s, --server <value>",
-      "Server address (http://<your-ip>:2283/api or https://<your-domain>/api)"
+      "Immich server address (http://<your-ip>:2283/api or https://<your-domain>/api)"
     ).env("IMMICH_SERVER_ADDRESS")
   )
   .addOption(
-    new Option("-d, --directory <value>", "Target Directory").env(
-      "IMMICH_TARGET_DIRECTORY"
-    )
+    new Option("-r, --recursive", "Recursive").env(
+      "IMMICH_RECURSIVE"
+    ).default(false)
   )
   .addOption(
     new Option("-y, --yes", "Assume yes on all interactive prompts").env(
@@ -98,14 +98,19 @@ program
       "Set a device UUID"
     ).env("IMMICH_DEVICE_UUID")
   )
-  .action(upload);
+  .argument(
+    '<paths...>'
+  )
+  .action((str, options) => {
+    upload(str, options);
+  });
 
 program.parse(process.argv);
 
-async function upload({
+async function upload(paths: String,{
   key,
   server,
-  directory,
+  recursive,
   yes: assumeYes,
   delete: deleteAssets,
   uploadThreads,
@@ -114,7 +119,6 @@ async function upload({
 }: any) {
   const endpoint = server;
   const deviceId = deviceUuid || (await si.uuid()).os || "CLI";
-  const osInfo = (await si.osInfo()).distro;
   const localAssets: any[] = [];
 
   // Ping server
@@ -126,24 +130,39 @@ async function upload({
   const user = await validateConnection(endpoint, key);
   log(chalk.yellow(`Connected to Immich with user ${user.email}`));
 
-  // Check if directory exist
-  log("[3] Checking directory...");
-  if (fs.existsSync(directory)) {
-    log(chalk.green("Directory status: OK"));
-  } else {
-    log(chalk.red("Error navigating to directory - check directory path"));
-    process.exit(1);
-  }
-
   // Index provided directory
   log("[4] Indexing files...");
-  const api = new fdir().withFullPaths().crawl(directory);
+  let crawler = new fdir().withFullPaths();
 
-  const files = (await api.withPromise()) as any[];
+  if (!recursive)
+  {
+    // Don't go into subfolders
+    crawler = crawler.withMaxDepth(0);
+  }
 
-  for (const filePath of files) {
+  let files: any[] = [];
+
+  for (const newPath of paths) {    
+    // Will throw error if path does not exist
+    await fs.promises.access(newPath);
+ 
+    if (await isDirectory(newPath)) 
+    {
+      // Is a directory so use the crawler to crawl it
+      const api = crawler.crawl(newPath);
+      files=files.concat((await api.withPromise()));
+
+    } else {
+      files.push(path.resolve(newPath));
+    }
+
+  }
+
+  const uniqueFiles = new Set(files);
+
+  for(const filePath of uniqueFiles) {
     const mimeType = mime.lookup(filePath) as string;
-    if (SUPPORTED_MIME.includes(mimeType)) {
+    if (SUPPORTED_MIME_TYPES.includes(mimeType)) {
       const fileStat = fs.statSync(filePath);
       localAssets.push({
         id: `${path.basename(filePath)}-${fileStat.size}`.replace(/\s+/g, ""),
@@ -489,7 +508,7 @@ async function pingServer(endpoint: string) {
     }
   } catch (e) {
     log(
-      chalk.red("Error connecting to server - check server address and port")
+      chalk.red("Error connecting to server - check server address and port: " + e)
     );
     process.exit(1);
   }
@@ -517,5 +536,8 @@ function getAssetType(filePath: string) {
   return mimeType.split("/")[0].toUpperCase();
 }
 
-// node bin/index.js upload --email testuser@email.com --password password --server http://10.1.15.216:2283/api -d /Users/alex/Documents/immich-cli-upload-test-location
-// node bin/index.js upload --help
+async function isDirectory(path: string) {  
+  const stats = await fs.promises.lstat(path)
+
+  return stats.isDirectory()
+}

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -370,10 +370,10 @@ async function startUpload(
       if (!exifDate) return null;
 
       if (typeof exifDate === 'string') {
-        return new Date(exifDate);
+        return new Date(exifDate).toISOString();
       }
 
-      return exifDate.toDate();
+      return exifDate.toDate().toISOString();
     };
 
     const fileCreatedAt = exifToDate(exifData?.DateTimeOriginal ?? exifData?.CreateDate ?? asset.fileCreatedAt);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "immich",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "immich",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.0",
@@ -14,6 +14,7 @@
         "cli-progress": "^3.10.0",
         "commander": "^9.0.0",
         "exifr": "^7.1.3",
+        "exiftool-vendored": "^21.2.0",
         "fdir": "^5.2.0",
         "form-data": "^4.0.0",
         "get-video-duration": "^4.0.0",
@@ -29,7 +30,7 @@
       "devDependencies": {
         "@types/cli-progress": "^3.11.0",
         "@types/mime-types": "^2.1.1",
-        "@types/node": "^18.7.8",
+        "@types/node": "^18.15.2",
         "typescript": "^4.7.4"
       }
     },
@@ -122,6 +123,11 @@
         "win32"
       ]
     },
+    "node_modules/@photostructure/tz-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-7.0.0.tgz",
+      "integrity": "sha512-pTRsZz7Sn4yAtItC7I4+0segDHosMyOtJgAXg+xvDOolT0Xz4IFWqBV33OMCWoaNd3oQb60wbWhLeCQgJCyZAA=="
+    },
     "node_modules/@types/cli-progress": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.0.tgz",
@@ -131,6 +137,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/luxon": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
+      "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA=="
+    },
     "node_modules/@types/mime-types": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.1.tgz",
@@ -138,9 +149,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.8.tgz",
-      "integrity": "sha512-/YP55EMK2341JkODUb8DM9O0x1SIz2aBvyF33Uf1c76St3VpsMXEIW0nxuKkq/5cxnbz0RD9cfwNZHEAZQD3ag==",
+      "version": "18.15.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.2.tgz",
+      "integrity": "sha512-sDPHm2wfx2QhrMDK0pOt2J4KLJMAcerqWNvnED0itPRJWvI+bK+uNHzcH1dFsBlf7G3u8tqXmRF3wkvL9yUwMw==",
       "dev": true
     },
     "node_modules/ansi-regex": {
@@ -173,6 +184,14 @@
       "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
       "dependencies": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/batch-cluster": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/batch-cluster/-/batch-cluster-12.0.0.tgz",
+      "integrity": "sha512-IYLp2rqdgB6f8rWklBnZpYxJVEN475SuBlykhwiDoHM9zOOXTqhKaJF2733dXUZcedApmn1oWfn1EUqQQf6hyg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/chalk": {
@@ -311,6 +330,40 @@
       "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
       "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
     },
+    "node_modules/exiftool-vendored": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-21.2.0.tgz",
+      "integrity": "sha512-zmojRmQPuTrRKJAxOqdXALQApaxJTKY3Gf1A9dxWgTKtdmgZDSmWbntoXFAl9CvPdAXPHq+VCUXL1g9Ue+iw+w==",
+      "dependencies": {
+        "@photostructure/tz-lookup": "^7.0.0",
+        "@types/luxon": "^3.2.0",
+        "batch-cluster": "^12.0.0",
+        "he": "^1.2.0",
+        "luxon": "^3.2.1"
+      },
+      "optionalDependencies": {
+        "exiftool-vendored.exe": "12.56.0",
+        "exiftool-vendored.pl": "12.56.0"
+      }
+    },
+    "node_modules/exiftool-vendored.exe": {
+      "version": "12.56.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.56.0.tgz",
+      "integrity": "sha512-Taf11Nct1ArOas7u/gm4QsVyfCcvjp3R1mWyzK1HPEtrGFOkNMyK7j0oPA0yYqZdLLNoqosXTMz/5x2WS2zL6Q==",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/exiftool-vendored.pl": {
+      "version": "12.56.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.56.0.tgz",
+      "integrity": "sha512-WLY8L//z6PGBXP/sZl/9SA8hJ1OoTBWw8eO2kDZPXInEt4fJKl2dTZD7M+PcehNIUhy0Ud/HZF5DK1MZc5au2w==",
+      "optional": true,
+      "os": [
+        "!win32"
+      ]
+    },
     "node_modules/fdir": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-5.2.0.tgz",
@@ -390,6 +443,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -426,6 +487,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "node_modules/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -771,6 +840,11 @@
       "integrity": "sha512-gPW2FZxexzCAOhGch0JFkeSSln+wcL5d1JDlJwfSJVEAShHf9MmxiWq0NpHoCSzFvK5qwl0C58KG180eKvd3mA==",
       "optional": true
     },
+    "@photostructure/tz-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-7.0.0.tgz",
+      "integrity": "sha512-pTRsZz7Sn4yAtItC7I4+0segDHosMyOtJgAXg+xvDOolT0Xz4IFWqBV33OMCWoaNd3oQb60wbWhLeCQgJCyZAA=="
+    },
     "@types/cli-progress": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.0.tgz",
@@ -780,6 +854,11 @@
         "@types/node": "*"
       }
     },
+    "@types/luxon": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
+      "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA=="
+    },
     "@types/mime-types": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.1.tgz",
@@ -787,9 +866,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.8.tgz",
-      "integrity": "sha512-/YP55EMK2341JkODUb8DM9O0x1SIz2aBvyF33Uf1c76St3VpsMXEIW0nxuKkq/5cxnbz0RD9cfwNZHEAZQD3ag==",
+      "version": "18.15.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.2.tgz",
+      "integrity": "sha512-sDPHm2wfx2QhrMDK0pOt2J4KLJMAcerqWNvnED0itPRJWvI+bK+uNHzcH1dFsBlf7G3u8tqXmRF3wkvL9yUwMw==",
       "dev": true
     },
     "ansi-regex": {
@@ -817,6 +896,11 @@
       "requires": {
         "follow-redirects": "^1.14.8"
       }
+    },
+    "batch-cluster": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/batch-cluster/-/batch-cluster-12.0.0.tgz",
+      "integrity": "sha512-IYLp2rqdgB6f8rWklBnZpYxJVEN475SuBlykhwiDoHM9zOOXTqhKaJF2733dXUZcedApmn1oWfn1EUqQQf6hyg=="
     },
     "chalk": {
       "version": "2.4.1",
@@ -927,6 +1011,32 @@
       "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
       "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
     },
+    "exiftool-vendored": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-21.2.0.tgz",
+      "integrity": "sha512-zmojRmQPuTrRKJAxOqdXALQApaxJTKY3Gf1A9dxWgTKtdmgZDSmWbntoXFAl9CvPdAXPHq+VCUXL1g9Ue+iw+w==",
+      "requires": {
+        "@photostructure/tz-lookup": "^7.0.0",
+        "@types/luxon": "^3.2.0",
+        "batch-cluster": "^12.0.0",
+        "exiftool-vendored.exe": "12.56.0",
+        "exiftool-vendored.pl": "12.56.0",
+        "he": "^1.2.0",
+        "luxon": "^3.2.1"
+      }
+    },
+    "exiftool-vendored.exe": {
+      "version": "12.56.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.56.0.tgz",
+      "integrity": "sha512-Taf11Nct1ArOas7u/gm4QsVyfCcvjp3R1mWyzK1HPEtrGFOkNMyK7j0oPA0yYqZdLLNoqosXTMz/5x2WS2zL6Q==",
+      "optional": true
+    },
+    "exiftool-vendored.pl": {
+      "version": "12.56.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.56.0.tgz",
+      "integrity": "sha512-WLY8L//z6PGBXP/sZl/9SA8hJ1OoTBWw8eO2kDZPXInEt4fJKl2dTZD7M+PcehNIUhy0Ud/HZF5DK1MZc5au2w==",
+      "optional": true
+    },
     "fdir": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-5.2.0.tgz",
@@ -973,6 +1083,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
     "human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -997,6 +1112,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,11 @@
         "chalk": "^2.4.1",
         "cli-progress": "^3.10.0",
         "commander": "^9.0.0",
-        "exifr": "^7.1.3",
         "exiftool-vendored": "^21.2.0",
         "fdir": "^5.2.0",
         "form-data": "^4.0.0",
-        "get-video-duration": "^4.0.0",
         "mime-types": "^2.1.34",
-        "node-machine-id": "^1.1.12",
         "p-limit": "3.1.0",
-        "simple-thumbnail": "^1.6.5",
         "systeminformation": "^5.11.6"
       },
       "bin": {
@@ -33,95 +29,6 @@
         "@types/node": "^18.15.2",
         "typescript": "^4.7.4"
       }
-    },
-    "node_modules/@ffprobe-installer/darwin-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/darwin-x64/-/darwin-x64-4.1.0.tgz",
-      "integrity": "sha512-ESwvOnbGVGK0r7bUdThSZAYipQOH0X79M4SoNZ5Tg77lq/RVbEdpObNEM2oRfLINbMlQQrezA4VYzt0n/DOkcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@ffprobe-installer/linux-arm": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm/-/linux-arm-4.3.2.tgz",
-      "integrity": "sha512-nZJbpTdh29swlgjVWi2fcV5jvbDFgo2y6a7X/uBsbely/TB158Fg0AncWJm7BbC0CwasGmSdqBsLtoSwXIcrlQ==",
-      "cpu": [
-        "arm"
-      ],
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ffprobe-installer/linux-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm64/-/linux-arm64-4.3.2.tgz",
-      "integrity": "sha512-9mCINruqx30UqB7kRvc75sj0yAPiDy21Fowow8bQDaAYAuO39MrFt/caLJrX11vCUfx2awolxKeuzTqcO9JjMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ffprobe-installer/linux-ia32": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-ia32/-/linux-ia32-4.1.0.tgz",
-      "integrity": "sha512-V2NeZpnly4HP1IU5IrsbbcRg8SWzC/SS0YDNSCjmhxGV2U8MUpW8c8KREE6nX56Dml8B8do5NNkTnaYCDPt3Xw==",
-      "cpu": [
-        "ia32"
-      ],
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ffprobe-installer/linux-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-x64/-/linux-x64-4.1.0.tgz",
-      "integrity": "sha512-Id+irHoI+Arq6tb3sHNQyzRrgUVVDgbmwpREDqQ+GDydiCw5ca7VnvRGXE/tBM2mVQ3/6m9wWHR7+xaW3gKJlA==",
-      "cpu": [
-        "x64"
-      ],
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ffprobe-installer/win32-ia32": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-ia32/-/win32-ia32-4.1.0.tgz",
-      "integrity": "sha512-G1pbRfk7XDi9EioT0gSR+O4ARdppS9kSXRzhnJOojUFD6x1k8Qv27RoOXeE5DtIE7TdX6UTywj8qA1BXI5zUUA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@ffprobe-installer/win32-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-x64/-/win32-x64-4.1.0.tgz",
-      "integrity": "sha512-gPW2FZxexzCAOhGch0JFkeSSln+wcL5d1JDlJwfSJVEAShHf9MmxiWq0NpHoCSzFvK5qwl0C58KG180eKvd3mA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@photostructure/tz-lookup": {
       "version": "7.0.0",
@@ -250,19 +157,6 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -271,29 +165,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -302,33 +177,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/exifr": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
-      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
     },
     "node_modules/exiftool-vendored": {
       "version": "21.2.0",
@@ -369,19 +217,6 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-5.2.0.tgz",
       "integrity": "sha512-skyI2Laxtj9GYzmktPgY6DT8uswXq+VoxH26SskykvEhTSbi7tRM/787uZt/p8maxrQCJdzC90zX1btbxiJ6lw=="
     },
-    "node_modules/ffprobe-darwin-arm64": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ffprobe-darwin-arm64/-/ffprobe-darwin-arm64-4.4.0.tgz",
-      "integrity": "sha512-09CDeZ5ej885k7aDw5c597sAufjmVwWKCuBskgAk+EqFJBWi9zrPDExFxjgSe4PNUlTNtFvm/jEEJH13rXAj5w==",
-      "cpu": [
-        "arm64"
-      ],
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
     "node_modules/follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -414,27 +249,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-video-duration": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/get-video-duration/-/get-video-duration-4.0.0.tgz",
-      "integrity": "sha512-FbWAsGg+iuHdIOiU5lGm/zQfGZgCoK2lzSWQczYfLTbOTQ1f8F2CjtjjDK0RorLfC5ndFNOO83Z+VJhalKPo9A==",
-      "dependencies": {
-        "execa": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-ffprobe-installer": "^1.2.3"
-      }
-    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -451,19 +265,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -472,22 +273,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
     "node_modules/luxon": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
@@ -495,11 +280,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/mime-db": {
       "version": "1.51.0",
@@ -520,67 +300,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/node-ffprobe-installer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/node-ffprobe-installer/-/node-ffprobe-installer-1.2.3.tgz",
-      "integrity": "sha512-g4KN1Z1wX6vL5yEPXcMzkg2huj42pqynWU7wyHAhP5axe+djYReUaa2aFtDkybqqXV729F+8OUGJbKwChkLefw==",
-      "optionalDependencies": {
-        "@ffprobe-installer/darwin-x64": "4.1.0",
-        "@ffprobe-installer/linux-arm": "4.3.2",
-        "@ffprobe-installer/linux-arm64": "4.3.2",
-        "@ffprobe-installer/linux-ia32": "4.1.0",
-        "@ffprobe-installer/linux-x64": "4.1.0",
-        "@ffprobe-installer/win32-ia32": "4.1.0",
-        "@ffprobe-installer/win32-x64": "4.1.0",
-        "ffprobe-darwin-arm64": "4.4.0"
-      }
-    },
-    "node_modules/node-machine-id": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
-      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
-    },
-    "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -593,91 +312,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "node_modules/simple-thumbnail": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/simple-thumbnail/-/simple-thumbnail-1.6.5.tgz",
-      "integrity": "sha512-HWN6oNyfvMWrwCW6CiVW5k1LUyl8neiim4Tx7v5FjvGEZM3rZpoKy3xEywrdEGvVlSzHQsaINp18eP7A7YYRiA==",
-      "dependencies": {
-        "duplexify": "^4.0.0"
-      }
-    },
-    "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -702,14 +336,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/supports-color": {
@@ -761,30 +387,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -798,48 +400,6 @@
     }
   },
   "dependencies": {
-    "@ffprobe-installer/darwin-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/darwin-x64/-/darwin-x64-4.1.0.tgz",
-      "integrity": "sha512-ESwvOnbGVGK0r7bUdThSZAYipQOH0X79M4SoNZ5Tg77lq/RVbEdpObNEM2oRfLINbMlQQrezA4VYzt0n/DOkcQ==",
-      "optional": true
-    },
-    "@ffprobe-installer/linux-arm": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm/-/linux-arm-4.3.2.tgz",
-      "integrity": "sha512-nZJbpTdh29swlgjVWi2fcV5jvbDFgo2y6a7X/uBsbely/TB158Fg0AncWJm7BbC0CwasGmSdqBsLtoSwXIcrlQ==",
-      "optional": true
-    },
-    "@ffprobe-installer/linux-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm64/-/linux-arm64-4.3.2.tgz",
-      "integrity": "sha512-9mCINruqx30UqB7kRvc75sj0yAPiDy21Fowow8bQDaAYAuO39MrFt/caLJrX11vCUfx2awolxKeuzTqcO9JjMQ==",
-      "optional": true
-    },
-    "@ffprobe-installer/linux-ia32": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-ia32/-/linux-ia32-4.1.0.tgz",
-      "integrity": "sha512-V2NeZpnly4HP1IU5IrsbbcRg8SWzC/SS0YDNSCjmhxGV2U8MUpW8c8KREE6nX56Dml8B8do5NNkTnaYCDPt3Xw==",
-      "optional": true
-    },
-    "@ffprobe-installer/linux-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-x64/-/linux-x64-4.1.0.tgz",
-      "integrity": "sha512-Id+irHoI+Arq6tb3sHNQyzRrgUVVDgbmwpREDqQ+GDydiCw5ca7VnvRGXE/tBM2mVQ3/6m9wWHR7+xaW3gKJlA==",
-      "optional": true
-    },
-    "@ffprobe-installer/win32-ia32": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-ia32/-/win32-ia32-4.1.0.tgz",
-      "integrity": "sha512-G1pbRfk7XDi9EioT0gSR+O4ARdppS9kSXRzhnJOojUFD6x1k8Qv27RoOXeE5DtIE7TdX6UTywj8qA1BXI5zUUA==",
-      "optional": true
-    },
-    "@ffprobe-installer/win32-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-x64/-/win32-x64-4.1.0.tgz",
-      "integrity": "sha512-gPW2FZxexzCAOhGch0JFkeSSln+wcL5d1JDlJwfSJVEAShHf9MmxiWq0NpHoCSzFvK5qwl0C58KG180eKvd3mA==",
-      "optional": true
-    },
     "@photostructure/tz-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-7.0.0.tgz",
@@ -946,70 +506,20 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
       "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw=="
     },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-      "requires": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
-      }
     },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      }
-    },
-    "exifr": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
-      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
     },
     "exiftool-vendored": {
       "version": "21.2.0",
@@ -1042,12 +552,6 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-5.2.0.tgz",
       "integrity": "sha512-skyI2Laxtj9GYzmktPgY6DT8uswXq+VoxH26SskykvEhTSbi7tRM/787uZt/p8maxrQCJdzC90zX1btbxiJ6lw=="
     },
-    "ffprobe-darwin-arm64": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ffprobe-darwin-arm64/-/ffprobe-darwin-arm64-4.4.0.tgz",
-      "integrity": "sha512-09CDeZ5ej885k7aDw5c597sAufjmVwWKCuBskgAk+EqFJBWi9zrPDExFxjgSe4PNUlTNtFvm/jEEJH13rXAj5w==",
-      "optional": true
-    },
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -1063,21 +567,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-    },
-    "get-video-duration": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/get-video-duration/-/get-video-duration-4.0.0.tgz",
-      "integrity": "sha512-FbWAsGg+iuHdIOiU5lGm/zQfGZgCoK2lzSWQczYfLTbOTQ1f8F2CjtjjDK0RorLfC5ndFNOO83Z+VJhalKPo9A==",
-      "requires": {
-        "execa": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-ffprobe-installer": "^1.2.3"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1088,40 +577,15 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
-    "human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
-    "is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
     "luxon": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
       "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "mime-db": {
       "version": "1.51.0",
@@ -1136,120 +600,12 @@
         "mime-db": "1.51.0"
       }
     },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-    },
-    "node-ffprobe-installer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/node-ffprobe-installer/-/node-ffprobe-installer-1.2.3.tgz",
-      "integrity": "sha512-g4KN1Z1wX6vL5yEPXcMzkg2huj42pqynWU7wyHAhP5axe+djYReUaa2aFtDkybqqXV729F+8OUGJbKwChkLefw==",
-      "requires": {
-        "@ffprobe-installer/darwin-x64": "4.1.0",
-        "@ffprobe-installer/linux-arm": "4.3.2",
-        "@ffprobe-installer/linux-arm64": "4.3.2",
-        "@ffprobe-installer/linux-ia32": "4.1.0",
-        "@ffprobe-installer/linux-x64": "4.1.0",
-        "@ffprobe-installer/win32-ia32": "4.1.0",
-        "@ffprobe-installer/win32-x64": "4.1.0",
-        "ffprobe-darwin-arm64": "4.4.0"
-      }
-    },
-    "node-machine-id": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
-      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
-    },
-    "npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "requires": {
-        "path-key": "^3.0.0"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "requires": {
-        "mimic-fn": "^2.1.0"
-      }
-    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "requires": {
         "yocto-queue": "^0.1.0"
-      }
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
-    },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "simple-thumbnail": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/simple-thumbnail/-/simple-thumbnail-1.6.5.tgz",
-      "integrity": "sha512-HWN6oNyfvMWrwCW6CiVW5k1LUyl8neiim4Tx7v5FjvGEZM3rZpoKy3xEywrdEGvVlSzHQsaINp18eP7A7YYRiA==",
-      "requires": {
-        "duplexify": "^4.0.0"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "string-width": {
@@ -1270,11 +626,6 @@
         "ansi-regex": "^5.0.1"
       }
     },
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1293,24 +644,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cli-progress": "^3.10.0",
     "commander": "^9.0.0",
     "exifr": "^7.1.3",
+    "exiftool-vendored": "^21.2.0",
     "fdir": "^5.2.0",
     "form-data": "^4.0.0",
     "get-video-duration": "^4.0.0",
@@ -49,7 +50,7 @@
   "devDependencies": {
     "@types/cli-progress": "^3.11.0",
     "@types/mime-types": "^2.1.1",
-    "@types/node": "^18.7.8",
+    "@types/node": "^18.15.2",
     "typescript": "^4.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,15 +27,11 @@
     "chalk": "^2.4.1",
     "cli-progress": "^3.10.0",
     "commander": "^9.0.0",
-    "exifr": "^7.1.3",
     "exiftool-vendored": "^21.2.0",
     "fdir": "^5.2.0",
     "form-data": "^4.0.0",
-    "get-video-duration": "^4.0.0",
     "mime-types": "^2.1.34",
-    "node-machine-id": "^1.1.12",
     "p-limit": "3.1.0",
-    "simple-thumbnail": "^1.6.5",
     "systeminformation": "^5.11.6"
   },
   "files": [


### PR DESCRIPTION
Immich recently migrated to the following library for date and time extraction: https://github.com/photostructure/exiftool-vendored.js#dates

The reason for the migration is that many photos have underspecified timezones. exiftool-vendored takes care of this nicely.

Users like myself with lots of DSLR photos not taken by mobile phones run into this issue all the time.

This pull request makes the date and time extraction consistent with immich itself.