### PR TITLE
Changed mime library to mime ^3.0.0 and add custom mimes for raw images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "commander": "^9.0.0",
         "fdir": "^5.2.0",
         "form-data": "^4.0.0",
-        "mime-types": "^2.1.34",
+        "mime": "^3.0.0",
         "p-limit": "3.1.0",
         "systeminformation": "^5.11.6"
       },
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@types/cli-progress": "^3.11.0",
+        "@types/mime": "^3.0.1",
         "@types/mime-types": "^2.1.1",
         "@types/node": "^18.15.2",
         "prettier": "^2.8.6",
@@ -38,6 +39,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
     },
     "node_modules/@types/mime-types": {
       "version": "2.1.1",
@@ -213,6 +220,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -356,6 +374,12 @@
         "@types/node": "*"
       }
     },
+    "@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
     "@types/mime-types": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.1.tgz",
@@ -482,6 +506,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
     },
     "mime-db": {
       "version": "1.51.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "^9.0.0",
     "fdir": "^5.2.0",
     "form-data": "^4.0.0",
-    "mime-types": "^2.1.34",
+    "mime": "^3.0.0",
     "p-limit": "3.1.0",
     "systeminformation": "^5.11.6"
   },
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@types/cli-progress": "^3.11.0",
+    "@types/mime": "^3.0.1",
     "@types/mime-types": "^2.1.1",
     "@types/node": "^18.15.2",
     "prettier": "^2.8.6",


### PR DESCRIPTION
Given https://github.com/immich-app/CLI/issues/47, the problem relied on in the fact that mime-types does not recognize raw photo formats (`.nef` for Nikon, probably more of them for other brands) and so those won't be uploaded.

My solution is to migrate from `mime-types` to `mime` to be able to use the ability to define custom mime types.
Because of that, all the non-default types are placed in an object associating their file extensions.