### PR TITLE
Feat ignore path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ build:
         tag=":$CI_COMMIT_REF_SLUG"
         echo "Running on branch '$CI_COMMIT_BRANCH': tag = $tag"
       fi
-    - docker build --pull -t "$CI_REGISTRY_IMAGE${tag}" .
+    - docker build --no-cache --pull -t "$CI_REGISTRY_IMAGE${tag}" .
     - docker push "$CI_REGISTRY_IMAGE${tag}" # this is commented out since it fails for now as I cannot have a docker repository behind traefik with forward-auth enabled.
   # Run this job in a branch where a Dockerfile exists
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+build:
+  image: docker:latest
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - echo "login into the docker registry at $CI_REGISTRY with user $CI_REGISTRY_USER or deploy user $CI_DEPLOY_USER and pwd $CI_DEPLOY_PASSWORD"
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+    #- docker login -u $CI_DEPLOY_USER -p $CI_DEPLOY_PASSWORD $CI_REGISTRY
+  # Default branch leaves tag empty (= latest tag)
+  # All other branches are tagged with the escaped branch name (commit ref slug)
+  script:
+    - |
+      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" ]]; then
+        tag=""
+        echo "Running on default branch '$CI_DEFAULT_BRANCH': tag = 'latest'"
+      else
+        tag=":$CI_COMMIT_REF_SLUG"
+        echo "Running on branch '$CI_COMMIT_BRANCH': tag = $tag"
+      fi
+    - docker build --pull -t "$CI_REGISTRY_IMAGE${tag}" .
+    - docker push "$CI_REGISTRY_IMAGE${tag}" # this is commented out since it fails for now as I cannot have a docker repository behind traefik with forward-auth enabled.
+  # Run this job in a branch where a Dockerfile exists
+  rules:
+    - if: $CI_COMMIT_BRANCH
+      exists:
+        - Dockerfile

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -123,9 +123,10 @@ program
       options.ignore=options.ignore.split(',')
       //log(`Ignore: ${options.ignore[1]}`)
     }
-    //else {
-    //  log(`No Ignore oprion given`)
-    //}
+    else {
+      log(`No Ignore oprion given`)
+      options.ignore=[]
+    }
 
     upload(paths, options);
   });

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -83,6 +83,12 @@ program
       'Upload assets recursively from the specified directory (DEPRECATED, use path argument with --recursive instead)',
     ).env('IMMICH_TARGET_DIRECTORY'),
   )
+  .addOption(
+    new Option(
+      '-i, --ignore <value>', 
+      'Ignore files matching regexp',
+    ).env('IMMICH_IGNORE_REGEXP')
+  )
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
   .action((paths, options) => {
     if (options.directory) {
@@ -113,6 +119,14 @@ program
         }
       }
     }
+    if (options.ignore) {
+      options.ignore=options.ignore.split(',')
+      //log(`Ignore: ${options.ignore[1]}`)
+    }
+    //else {
+    //  log(`No Ignore oprion given`)
+    //}
+
     upload(paths, options);
   });
 
@@ -130,6 +144,7 @@ async function upload(
     album: createAlbums,
     deviceUuid: deviceUuid,
     import: doImport,
+    ignore,
   }: any,
 ) {
   const endpoint = server;
@@ -185,21 +200,40 @@ async function upload(
   const uniqueFiles = new Set(files);
 
   for (const filePath of uniqueFiles) {
-    const mimeType = mime.lookup(filePath) as string;
-    if (SUPPORTED_MIME.includes(mimeType)) {
-      try {
-        const fileStat = fs.statSync(filePath);
-        localAssets.push({
-          id: `${path.basename(filePath)}-${fileStat.size}`.replace(/\s+/g, ''),
-          filePath,
-        });
-      } catch (e) {
-        errorAssets.push({
-          file: filePath,
-          reason: e,
-          response: e.response?.data,
-        });
-        continue;
+
+    //log(`Iterating over ${filePath} ${path.basename(filePath)}`)
+    //var debug=filePath.match("@eaDir")
+    //log(`Iterating over2 ${debug}`)
+
+    var doIgnore=false
+    for (const regexp of ignore) {
+      if (filePath.match(regexp)) {
+        //log(`MATCH: ${regexp} in ${filePath}`)
+        doIgnore=true
+        break
+      }
+      //else {
+      //  log(`NOmatch: ${regexp} in ${filePath}`)
+      //}
+    }
+
+    if (!doIgnore) {
+      const mimeType = mime.lookup(filePath) as string;
+      if (SUPPORTED_MIME.includes(mimeType)) {
+        try {
+          const fileStat = fs.statSync(filePath);
+          localAssets.push({
+            id: `${path.basename(filePath)}-${fileStat.size}`.replace(/\s+/g, ''),
+            filePath,
+          });
+        } catch (e) {
+          errorAssets.push({
+            file: filePath,
+            reason: e,
+            response: e.response?.data,
+          });
+          continue;
+        }
       }
     }
   }


### PR DESCRIPTION
Probably merits a bit of cleanup but this PR allows to add the argument `--ignore someRegExp,someOtherRegExp` to the cli, which is working for me to manually import in read-only mode and skip files in @eaDir or #recycle directory. Would have added a check for hidden file to ignore them as well but didn't find it in the fs package to fix https://github.com/immich-app/CLI/issues/73.

It's a bit too late for me to do the cleanup, might give it a try later if you find this is of interest.