### PR TITLE
fix: add assets to album

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -445,7 +445,7 @@ async function addAssetsToAlbum(endpoint: string, key: string, albumId: string, 
   try {
     await axios.put(
       `${endpoint}/album/${albumId}/assets`,
-      { assetIds: [...new Set(assetIds)] },
+      { ids: [...new Set(assetIds)] },
       {
         headers: { 'x-api-key': key },
       },


### PR DESCRIPTION
Tested via command with `--album` and verified an album was created after a successful upload.

Note: since this CLI is installed on the `immich-server` image, it would be good promote this patch to that image asap.